### PR TITLE
Updated setup.py to install on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(	long_description=open("README.rst").read(),
 	url="""http://github.com/karimbahgat/PyCRS""",
 	version="""0.1.2""",
 	keywords="""GIS spatial CRS coordinates format""",
-	packages=['pycrs', 'pycrs\\elements'],
+	packages=['pycrs', 'pycrs/elements'],
 	classifiers=['License :: OSI Approved', 'Programming Language :: Python', 'Development Status :: 4 - Beta', 'Intended Audience :: Developers', 'Intended Audience :: Science/Research', 'Intended Audience :: End Users/Desktop', 'Topic :: Scientific/Engineering :: GIS'],
 	description="""GIS package for reading, writing, and converting between CRS formats.""",
 	)


### PR DESCRIPTION
I fixed a line in setup.py  allow pip  installation via on my linux box.  I changed "\\" to "/".

Setuptools documentation states: "Also notice that if you use paths, you must use a forward slash (/) as the path separator, even if you are on Windows. Setuptools automatically converts slashes to appropriate platform-specific separators at build time."   Source: http://pythonhosted.org/setuptools/setuptools.html#including-data-files