### PR TITLE
fix: loader.from_url().  

### DIFF
--- a/pycrs/loader.py
+++ b/pycrs/loader.py
@@ -3,12 +3,14 @@ Convenience functions for loading from different sources.
 """
 
 import json
+import sys
 try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2
 from . import parser
 
+PY3 = (int(sys.version_info[0]) > 2)
 
 #################
 # USER FUNCTIONS
@@ -30,6 +32,10 @@ def from_url(url, format=None):
     """
     # first get string from url
     string = urllib2.urlopen(url).read()
+    
+    if PY3 is True:
+        # decode bytes into string
+        string = string.decode('utf-8')
 
     # then determine parser
     if format:

--- a/pycrs/parser.py
+++ b/pycrs/parser.py
@@ -126,7 +126,7 @@ def from_unknown_wkt(string, strict=False):
     # use args to create crs
     return _from_wkt(string, None, strict)
 
-def _from_wkt(string, wkttype, strict=False):
+def _from_wkt(string, wkttype=None, strict=False):
     """
     Internal method for parsing wkt, with minor differences depending on ogc or esri style.
 
@@ -729,7 +729,7 @@ def from_unknown_text(text, strict=False):
 
     Arguments:
 
-    - *string*: The crs text representation of unknown type. 
+    - *text*: The crs text representation of unknown type. 
     - *strict* (optional): When True, the parser is strict about names having to match
         exactly with upper and lowercases. Default is not strict (False).
 
@@ -738,25 +738,27 @@ def from_unknown_text(text, strict=False):
     - CRS object.
     """
 
-    if string.startswith("+"):
-        from_proj4(string, strict)
+    if text.startswith("+"):
+        crs = from_proj4(text, strict)
 
-    elif string.startswith(("PROJCS[","GEOGCS[")):
-        from_unknown_wkt(string, strict)
+    elif text.startswith(("PROJCS[","GEOGCS[")):
+        crs = from_unknown_wkt(text, strict)
 
-    #elif string.startswith("urn:"):
-    #    from_ogc_urn(string, strict)
+    #elif text.startswith("urn:"):
+    #    crs = from_ogc_urn(text, strict)
 
-    elif string.startswith("EPSG:"):
-        from_epsg_code(string.split(":")[1])
+    elif text.startswith("EPSG:"):
+        crs = from_epsg_code(text.split(":")[1])
 
-    elif string.startswith("ESRI:"):
-        from_esri_code(string.split(":")[1])
+    elif text.startswith("ESRI:"):
+        crs = from_esri_code(text.split(":")[1])
 
-    elif string.startswith("SR-ORG:"):
-        from_sr_code(string.split(":")[1])
+    elif text.startswith("SR-ORG:"):
+        crs = from_sr_code(text.split(":")[1])
 
     else: raise Exception("Could not detect which type of crs")
+    
+    return crs
 
 
 ##def from_geotiff_parameters(**params):

--- a/testpycrs.py
+++ b/testpycrs.py
@@ -1,0 +1,16 @@
+import unittest
+
+import pycrs
+
+class TestLoaderMethods(unittest.TestCase):
+    def test_from_url(self):
+        # before patch crs_obj would be None
+        crs_obj = pycrs.loader.from_url('http://spatialreference.org/ref/esri/102630/esriwkt/')
+        proj4 = crs_obj.to_proj4()
+        # make sure it outputs something
+        self.assertGreater(len(proj4), 0)
+        # does the output seem to be proj4?
+        self.assertEqual(proj4[0], '+')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add unittest testpycrs.py using python framework for loader.from_url().  parser.from_unknown_text() returns output.  loader.from_url() in Python 3 urllib decodes bytes.

You can download testpycrs.py or do this in Python 2 or 3.
Here is the test
```Python
In [1]: import pycrs

In [2]: crs = pycrs.loader.from_url('http://spatialreference.org/ref/esri/102630/esriwkt/')
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-a113c27d1212> in <module>()
----> 1 crs = pycrs.loader.from_url('http://spatialreference.org/ref/esri/102630/esriwkt/')

/home/micah/prj2/PyCRS/pycrs/loader.py in from_url(url, format)
     42 
     43     # then load
---> 44     crs = func(string)
     45     return crs
     46 

/home/micah/prj2/PyCRS/pycrs/parser.py in from_unknown_text(text, strict)
    739     """
    740 
--> 741     if string.startswith("+"):
    742         from_proj4(string, strict)
    743 

NameError: global name 'string' is not defined
```

This patch fixes this function.