### PR TITLE
Added scale factor as possibility for ESRI WKT

### DIFF
--- a/pycrs/elements/parameters.py
+++ b/pycrs/elements/parameters.py
@@ -134,6 +134,7 @@ class Azimuth:
 ##+k_0       Scaling factor (new name)
 class ScalingFactor:
     proj4 = "+k"
+    esri_wkt = "Scale_Factor"
     ogc_wkt = "scale_factor"
     
     def __init__(self, value):
@@ -146,8 +147,7 @@ class ScalingFactor:
         return 'PARAMETER["scale_factor", %s]' %self.value
 
     def to_esri_wkt(self):
-        # REALLY??
-        raise Exception("Parameter %r not supported by ESRI WKT" % self)
+        return 'PARAMETER["Scale_Factor", %s]' %self.value
 
     def to_geotiff(self):
         pass


### PR DESCRIPTION
ESRI WKT does seem to have a scale factor. [This standard doc](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) has ESRI as a "submitting organization" and it clearly has a scale factor included. I've also looked at some `.prj` files that ESRI includes with ArcGIS, and they have a scale factor as well.